### PR TITLE
Bugfix - Seed generation and validation on score submission

### DIFF
--- a/src/app/components/game/DicePreview.tsx
+++ b/src/app/components/game/DicePreview.tsx
@@ -1,6 +1,6 @@
 import AgentPreview from '@/game/AgentPreview'
 import { calculateTargetScore, getDiceCounts } from '@/logic/empress'
-import { getUTCISOString } from 'lib/util'
+import { getISODateOnlyString } from 'lib/util'
 
 interface DicePreviewProps {
     readonly date: Date
@@ -9,7 +9,7 @@ interface DicePreviewProps {
 export default function DicePreview({ date }: DicePreviewProps) {
     const mpDieSize_Count = getDiceCounts({
         date: date,
-        seed: getUTCISOString(date),
+        seed: getISODateOnlyString(date),
         turnHistory: []
     })
     const previewDice = mpDieSize_Count

--- a/src/app/components/game/DicePreview.tsx
+++ b/src/app/components/game/DicePreview.tsx
@@ -1,6 +1,6 @@
 import AgentPreview from '@/game/AgentPreview'
 import { calculateTargetScore, getDiceCounts } from '@/logic/empress'
-import { dateOnlyString } from 'lib/util'
+import { getUTCISOString } from 'lib/util'
 
 interface DicePreviewProps {
     readonly date: Date
@@ -9,7 +9,7 @@ interface DicePreviewProps {
 export default function DicePreview({ date }: DicePreviewProps) {
     const mpDieSize_Count = getDiceCounts({
         date: date,
-        seed: dateOnlyString(date),
+        seed: getUTCISOString(date),
         turnHistory: []
     })
     const previewDice = mpDieSize_Count

--- a/src/app/components/ui/DateSelector.tsx
+++ b/src/app/components/ui/DateSelector.tsx
@@ -2,7 +2,7 @@
 
 import Arrow from '@/svg/Arrow'
 import clsx from 'clsx'
-import { getUTCISOString } from 'lib/util'
+import { getISODateOnlyString } from 'lib/util'
 import React, { useLayoutEffect, useState } from 'react'
 import { animated, useTransition, useReducedMotion } from '@react-spring/web'
 
@@ -68,7 +68,7 @@ export default function DateSelector({
                         }
                         style={springs}
                     >
-                        {getUTCISOString(item)}
+                        {getISODateOnlyString(item)}
                     </animated.div>
                 ))
             }

--- a/src/app/components/ui/DateSelector.tsx
+++ b/src/app/components/ui/DateSelector.tsx
@@ -2,7 +2,7 @@
 
 import Arrow from '@/svg/Arrow'
 import clsx from 'clsx'
-import { dateOnlyString } from 'lib/util'
+import { getUTCISOString } from 'lib/util'
 import React, { useLayoutEffect, useState } from 'react'
 import { animated, useTransition, useReducedMotion } from '@react-spring/web'
 
@@ -68,7 +68,7 @@ export default function DateSelector({
                         }
                         style={springs}
                     >
-                        {dateOnlyString(item)}
+                        {getUTCISOString(item)}
                     </animated.div>
                 ))
             }

--- a/src/app/components/ui/QueryParamDateSelector.tsx
+++ b/src/app/components/ui/QueryParamDateSelector.tsx
@@ -4,7 +4,7 @@ import {
     addDays,
     getUTCISOString,
     ensureValidDate,
-    getTodayWithoutTime
+    getDateWithoutTime
 } from 'lib/util'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import DateSelector from './DateSelector'
@@ -24,7 +24,7 @@ export default function QueryParamDateSelector({
     const currentDateString = searchParams.get('date')?.toString()
     const currentDate = ensureValidDate(
         currentDateString,
-        getTodayWithoutTime()
+        getDateWithoutTime(new Date())
     )
 
     function handleNewDate(date: Date) {

--- a/src/app/components/ui/QueryParamDateSelector.tsx
+++ b/src/app/components/ui/QueryParamDateSelector.tsx
@@ -2,7 +2,7 @@
 
 import {
     addDays,
-    dateOnlyString,
+    getUTCISOString,
     ensureValidDate,
     getTodayWithoutTime
 } from 'lib/util'
@@ -29,7 +29,7 @@ export default function QueryParamDateSelector({
 
     function handleNewDate(date: Date) {
         const params = new URLSearchParams(searchParams)
-        params.set('date', dateOnlyString(date))
+        params.set('date', getUTCISOString(date))
         router.replace(`${pathname}?${params.toString()}`)
     }
 

--- a/src/app/components/ui/QueryParamDateSelector.tsx
+++ b/src/app/components/ui/QueryParamDateSelector.tsx
@@ -2,7 +2,7 @@
 
 import {
     addDays,
-    getUTCISOString,
+    getISODateOnlyString,
     ensureValidDate,
     getDateWithoutTime
 } from 'lib/util'
@@ -29,7 +29,7 @@ export default function QueryParamDateSelector({
 
     function handleNewDate(date: Date) {
         const params = new URLSearchParams(searchParams)
-        params.set('date', getUTCISOString(date))
+        params.set('date', getISODateOnlyString(date))
         router.replace(`${pathname}?${params.toString()}`)
     }
 

--- a/src/app/game/EndScreen.tsx
+++ b/src/app/game/EndScreen.tsx
@@ -1,7 +1,7 @@
 import Hourglass from '@/svg/Hourglass'
 import Chariot from '@/svg/tarot/Chariot'
 import Button from '@/ui/Button'
-import { getUTCISOString } from 'lib/util'
+import { getISODateOnlyString } from 'lib/util'
 import { startTransition, useActionState, useContext } from 'react'
 import {
     calculateTargetScore,
@@ -42,7 +42,7 @@ export default function EndScreen({
     const finalScore = getScore(getCurrentState(session))
     const targetScore = calculateTargetScore(getDiceCounts(session))
     const numTurns = session.turnHistory.length
-    const dateString = getUTCISOString(date)
+    const dateString = getISODateOnlyString(date)
     return (
         <div className="not-motion-reduce:animate-slidefromtop relative flex h-full flex-col items-center select-none">
             <div className="fill-gold bg-background w-full sm:h-screen">

--- a/src/app/game/EndScreen.tsx
+++ b/src/app/game/EndScreen.tsx
@@ -1,7 +1,7 @@
 import Hourglass from '@/svg/Hourglass'
 import Chariot from '@/svg/tarot/Chariot'
 import Button from '@/ui/Button'
-import { dateOnlyString } from 'lib/util'
+import { getUTCISOString } from 'lib/util'
 import { startTransition, useActionState, useContext } from 'react'
 import {
     calculateTargetScore,
@@ -42,7 +42,7 @@ export default function EndScreen({
     const finalScore = getScore(getCurrentState(session))
     const targetScore = calculateTargetScore(getDiceCounts(session))
     const numTurns = session.turnHistory.length
-    const dateString = dateOnlyString(date)
+    const dateString = getUTCISOString(date)
     return (
         <div className="not-motion-reduce:animate-slidefromtop relative flex h-full flex-col items-center select-none">
             <div className="fill-gold bg-background w-full sm:h-screen">

--- a/src/app/game/GameScreen.tsx
+++ b/src/app/game/GameScreen.tsx
@@ -7,12 +7,7 @@ import Bribe from '@/game/locations/Bribe'
 import Delay from '@/game/locations/Delay'
 import Influence from '@/game/locations/Influence'
 import Button from '@/ui/Button'
-import {
-    addYears,
-    getUTCISOString,
-    ensureValidDate,
-    getDateWithoutTime
-} from 'lib/util'
+import { getUTCISOString } from 'lib/util'
 import Hourglass from '@/svg/Hourglass'
 import EndScreen from './EndScreen'
 import { useNextStep } from 'nextstepjs'
@@ -28,15 +23,13 @@ import Agent from '@/game/Agent'
 import ButtonLink from '@/ui/ButtonLink'
 import { AnimationContext } from '@/ui/AnimationContext'
 import { generateSeed } from 'lib/random'
-import { notFound, useSearchParams } from 'next/navigation'
 
-export default function GameScreen() {
+interface GameScreenProps {
+    readonly date: Date
+}
+
+export default function GameScreen({ date }: GameScreenProps) {
     const [currentDateTime] = useState(new Date())
-    const dateParam = useSearchParams().get('date') ?? undefined
-    const date = ensureValidDate(dateParam, getDateWithoutTime(currentDateTime))
-    const oneYearAgo = addYears(getDateWithoutTime(currentDateTime), -1)
-    if (date < oneYearAgo) notFound()
-
     const dateString = getUTCISOString(date)
     const { startNextStep } = useNextStep()
     const [curSession, setSession] = useState<EG.Session>(() => {

--- a/src/app/game/GameScreen.tsx
+++ b/src/app/game/GameScreen.tsx
@@ -9,9 +9,9 @@ import Influence from '@/game/locations/Influence'
 import Button from '@/ui/Button'
 import {
     addYears,
-    dateOnlyString,
+    getUTCISOString,
     ensureValidDate,
-    getTodayWithoutTime
+    getDateWithoutTime
 } from 'lib/util'
 import Hourglass from '@/svg/Hourglass'
 import EndScreen from './EndScreen'
@@ -31,17 +31,18 @@ import { generateSeed } from 'lib/random'
 import { notFound, useSearchParams } from 'next/navigation'
 
 export default function GameScreen() {
+    const [currentDateTime] = useState(new Date())
     const dateParam = useSearchParams().get('date') ?? undefined
-    const date = ensureValidDate(dateParam, getTodayWithoutTime())
-    const oneYearAgo = addYears(getTodayWithoutTime(), -1)
+    const date = ensureValidDate(dateParam, getDateWithoutTime(currentDateTime))
+    const oneYearAgo = addYears(getDateWithoutTime(currentDateTime), -1)
     if (date < oneYearAgo) notFound()
 
-    const dateString = dateOnlyString(date)
+    const dateString = getUTCISOString(date)
     const { startNextStep } = useNextStep()
     const [curSession, setSession] = useState<EG.Session>(() => {
         return {
             date: date,
-            seed: generateSeed(date).toString(),
+            seed: generateSeed(date, currentDateTime).toString(),
             turnHistory: []
         }
     })
@@ -84,7 +85,10 @@ export default function GameScreen() {
                 handleTryAgain={() =>
                     setSession({
                         date: curSession.date,
-                        seed: generateSeed(curSession.date).toString(),
+                        seed: generateSeed(
+                            curSession.date,
+                            currentDateTime
+                        ).toString(),
                         turnHistory: []
                     })
                 }

--- a/src/app/game/GameScreen.tsx
+++ b/src/app/game/GameScreen.tsx
@@ -7,7 +7,7 @@ import Bribe from '@/game/locations/Bribe'
 import Delay from '@/game/locations/Delay'
 import Influence from '@/game/locations/Influence'
 import Button from '@/ui/Button'
-import { getUTCISOString } from 'lib/util'
+import { getISODateOnlyString } from 'lib/util'
 import Hourglass from '@/svg/Hourglass'
 import EndScreen from './EndScreen'
 import { useNextStep } from 'nextstepjs'
@@ -29,13 +29,12 @@ interface GameScreenProps {
 }
 
 export default function GameScreen({ date }: GameScreenProps) {
-    const [currentDateTime] = useState(new Date())
-    const dateString = getUTCISOString(date)
+    const dateString = getISODateOnlyString(date)
     const { startNextStep } = useNextStep()
     const [curSession, setSession] = useState<EG.Session>(() => {
         return {
             date: date,
-            seed: generateSeed(date, currentDateTime).toString(),
+            seed: generateSeed(date, new Date()).toString(),
             turnHistory: []
         }
     })
@@ -80,7 +79,7 @@ export default function GameScreen({ date }: GameScreenProps) {
                         date: curSession.date,
                         seed: generateSeed(
                             curSession.date,
-                            currentDateTime
+                            new Date()
                         ).toString(),
                         turnHistory: []
                     })

--- a/src/app/game/page.tsx
+++ b/src/app/game/page.tsx
@@ -1,10 +1,16 @@
+import { addYears, ensureValidDate, getDateWithoutTime } from 'lib/util'
+import { notFound } from 'next/navigation'
 import GameScreen from './GameScreen'
-import { Suspense } from 'react'
 
-export default function Page() {
-    return (
-        <Suspense>
-            <GameScreen />
-        </Suspense>
-    )
+export default async function Page(props: {
+    searchParams?: Promise<{
+        date?: string
+    }>
+}) {
+    const searchParams = await props.searchParams
+    const dateString = searchParams?.date
+    const date = ensureValidDate(dateString, getDateWithoutTime(new Date()))
+    const oneYearAgo = addYears(getDateWithoutTime(new Date()), -1)
+    if (date < oneYearAgo) notFound()
+    return <GameScreen date={date} />
 }

--- a/src/app/play/page.tsx
+++ b/src/app/play/page.tsx
@@ -11,6 +11,7 @@ import Fortune from '@/svg/tarot/Fortune'
 import DicePreview from '../components/game/DicePreview'
 import NavAnimator from 'app/components/navigation/NavAnimator'
 import { Suspense } from 'react'
+import { notFound } from 'next/navigation'
 
 export default async function Page(props: {
     searchParams?: Promise<{
@@ -19,11 +20,9 @@ export default async function Page(props: {
 }) {
     const searchParams = await props.searchParams
     const dateString = searchParams?.date
-    const selectedDate = ensureValidDate(
-        dateString,
-        getDateWithoutTime(new Date())
-    )
+    const date = ensureValidDate(dateString, getDateWithoutTime(new Date()))
     const oneYearAgo = addYears(getDateWithoutTime(new Date()), -1)
+    if (date < oneYearAgo) notFound()
     return (
         <NavAnimator thisPage="/play">
             <div
@@ -38,15 +37,15 @@ export default async function Page(props: {
                         max={getDateWithoutTime(new Date())}
                         min={oneYearAgo}
                     />
-                    <DicePreview date={selectedDate} />
+                    <DicePreview date={date} />
                     <div id="scores" className="max-h-50 grow sm:max-h-60">
                         <Suspense>
-                            <Scores date={selectedDate} />
+                            <Scores date={date} />
                         </Suspense>
                     </div>
                     <div id="button-play" className="z-20">
                         <ButtonLink
-                            href={`/game?date=${getUTCISOString(selectedDate)}`}
+                            href={`/game?date=${getUTCISOString(date)}`}
                         >
                             {'Play'}
                         </ButtonLink>

--- a/src/app/play/page.tsx
+++ b/src/app/play/page.tsx
@@ -1,8 +1,8 @@
 import {
     addYears,
-    dateOnlyString,
+    getUTCISOString,
     ensureValidDate,
-    getTodayWithoutTime
+    getDateWithoutTime
 } from 'lib/util'
 import ButtonLink from '@/ui/ButtonLink'
 import Scores from 'app/play/Scores'
@@ -19,8 +19,11 @@ export default async function Page(props: {
 }) {
     const searchParams = await props.searchParams
     const dateString = searchParams?.date
-    const selectedDate = ensureValidDate(dateString, getTodayWithoutTime())
-    const oneYearAgo = addYears(getTodayWithoutTime(), -1)
+    const selectedDate = ensureValidDate(
+        dateString,
+        getDateWithoutTime(new Date())
+    )
+    const oneYearAgo = addYears(getDateWithoutTime(new Date()), -1)
     return (
         <NavAnimator thisPage="/play">
             <div
@@ -32,7 +35,7 @@ export default async function Page(props: {
                 </div>
                 <div className="absolute flex h-full max-w-120 flex-col items-center justify-center gap-2 p-5">
                     <QueryParamDateSelector
-                        max={getTodayWithoutTime()}
+                        max={getDateWithoutTime(new Date())}
                         min={oneYearAgo}
                     />
                     <DicePreview date={selectedDate} />
@@ -43,7 +46,7 @@ export default async function Page(props: {
                     </div>
                     <div id="button-play" className="z-20">
                         <ButtonLink
-                            href={`/game?date=${dateOnlyString(selectedDate)}`}
+                            href={`/game?date=${getUTCISOString(selectedDate)}`}
                         >
                             {'Play'}
                         </ButtonLink>

--- a/src/app/play/page.tsx
+++ b/src/app/play/page.tsx
@@ -1,6 +1,6 @@
 import {
     addYears,
-    getUTCISOString,
+    getISODateOnlyString,
     ensureValidDate,
     getDateWithoutTime
 } from 'lib/util'
@@ -45,7 +45,7 @@ export default async function Page(props: {
                     </div>
                     <div id="button-play" className="z-20">
                         <ButtonLink
-                            href={`/game?date=${getUTCISOString(date)}`}
+                            href={`/game?date=${getISODateOnlyString(date)}`}
                         >
                             {'Play'}
                         </ButtonLink>

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -1,4 +1,4 @@
-import { getUTCISOString } from 'lib/util'
+import { getISODateOnlyString } from 'lib/util'
 import postgres from 'postgres'
 
 interface Score {
@@ -26,7 +26,7 @@ export async function getTopNScoresByDate(date: Date, n: number) {
     return await sql<Score[]>`
   SELECT *
   FROM scores
-  WHERE date = ${getUTCISOString(date)}
+  WHERE date = ${getISODateOnlyString(date)}
   ORDER BY score DESC, numturns ASC
   LIMIT ${n}`
 }
@@ -36,7 +36,7 @@ export async function getScoreStatsByDate(date: Date) {
     WITH today_scores AS (
     SELECT score
     FROM scores
-    WHERE date = ${getUTCISOString(date)}
+    WHERE date = ${getISODateOnlyString(date)}
 )
   SELECT COUNT(score), MIN(score), MAX(score)
   FROM today_scores`
@@ -53,7 +53,7 @@ export async function getScoreBucketsByDate(
   WITH buckets_cte AS (
     SELECT WIDTH_BUCKET(score, ${min}, ${max}, ${numBuckets}) AS bucket_number
     FROM scores
-    WHERE date = ${getUTCISOString(date)}
+    WHERE date = ${getISODateOnlyString(date)}
 )
 SELECT
     bucket_number,

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -1,4 +1,4 @@
-import { dateOnlyString } from 'lib/util'
+import { getUTCISOString } from 'lib/util'
 import postgres from 'postgres'
 
 interface Score {
@@ -26,7 +26,7 @@ export async function getTopNScoresByDate(date: Date, n: number) {
     return await sql<Score[]>`
   SELECT *
   FROM scores
-  WHERE date = ${dateOnlyString(date)}
+  WHERE date = ${getUTCISOString(date)}
   ORDER BY score DESC, numturns ASC
   LIMIT ${n}`
 }
@@ -36,7 +36,7 @@ export async function getScoreStatsByDate(date: Date) {
     WITH today_scores AS (
     SELECT score
     FROM scores
-    WHERE date = ${dateOnlyString(date)}
+    WHERE date = ${getUTCISOString(date)}
 )
   SELECT COUNT(score), MIN(score), MAX(score)
   FROM today_scores`
@@ -53,7 +53,7 @@ export async function getScoreBucketsByDate(
   WITH buckets_cte AS (
     SELECT WIDTH_BUCKET(score, ${min}, ${max}, ${numBuckets}) AS bucket_number
     FROM scores
-    WHERE date = ${dateOnlyString(date)}
+    WHERE date = ${getUTCISOString(date)}
 )
 SELECT
     bucket_number,

--- a/src/lib/logic/empress.ts
+++ b/src/lib/logic/empress.ts
@@ -6,7 +6,7 @@ import {
     randomRoll,
     weightedSelect
 } from 'lib/random'
-import { dateOnlyString } from 'lib/util'
+import { getUTCISOString } from 'lib/util'
 
 export type Session = {
     date: Date
@@ -62,7 +62,7 @@ function getConfig(date: Date): EmpressConfig {
 
 export function getDiceCounts(session: Session): Map<DieSize, number> {
     // Dice counts are based just on the date, whereas the rolls are based on the session's full seed.
-    const rand = random_splitmix32(hash_cyrb53(dateOnlyString(session.date)))
+    const rand = random_splitmix32(hash_cyrb53(getUTCISOString(session.date)))
     const {
         dieBaseWeights,
         minDiceCount,

--- a/src/lib/logic/empress.ts
+++ b/src/lib/logic/empress.ts
@@ -6,7 +6,7 @@ import {
     randomRoll,
     weightedSelect
 } from 'lib/random'
-import { getUTCISOString } from 'lib/util'
+import { getISODateOnlyString } from 'lib/util'
 
 export type Session = {
     date: Date
@@ -62,7 +62,9 @@ function getConfig(date: Date): EmpressConfig {
 
 export function getDiceCounts(session: Session): Map<DieSize, number> {
     // Dice counts are based just on the date, whereas the rolls are based on the session's full seed.
-    const rand = random_splitmix32(hash_cyrb53(getUTCISOString(session.date)))
+    const rand = random_splitmix32(
+        hash_cyrb53(getISODateOnlyString(session.date))
+    )
     const {
         dieBaseWeights,
         minDiceCount,

--- a/src/lib/random.test.ts
+++ b/src/lib/random.test.ts
@@ -1,4 +1,4 @@
-import { weightedSelect } from './random'
+import { generateSeed, validateSeed, weightedSelect } from './random'
 
 describe('weightedSelect', () => {
     it('should select first index when first weight is 1 and others are 0', () => {
@@ -35,5 +35,17 @@ describe('weightedSelect', () => {
         const mockRand = () => 0.5
         const weights = [0, 1, 0]
         expect(weightedSelect(weights, mockRand)).toBe(1)
+    })
+})
+
+describe('generateSeed', () => {
+    it('should always be valid', () => {
+        // Generate a seed after 5pm pacific time
+        const gameDate = new Date('2025-10-05')
+        const currentLocalDate = new Date('2025-10-04T17:01-07:00')
+        const seed = generateSeed(gameDate, currentLocalDate)
+
+        // Try to validate that seed
+        expect(validateSeed(gameDate, `${seed}`)).toBe(true)
     })
 })

--- a/src/lib/random.ts
+++ b/src/lib/random.ts
@@ -1,5 +1,4 @@
-import _ from 'lodash'
-import { addDays } from './util'
+import { addDays, withTimeOf } from './util'
 
 /*
     cyrb53 (c) 2018 bryc (github.com/bryc)
@@ -67,15 +66,8 @@ export function weightedSelect(weights: number[], rand: () => number): number {
     })
 }
 
-export function generateSeed(date: Date): number {
-    const currentDateTime = new Date()
-    const seedDate = _.cloneDeep(date)
-    seedDate.setUTCHours(
-        currentDateTime.getUTCHours(),
-        currentDateTime.getUTCMinutes(),
-        currentDateTime.getUTCSeconds(),
-        currentDateTime.getUTCMilliseconds()
-    )
+export function generateSeed(date: Date, currentDateTime: Date): number {
+    const seedDate = withTimeOf(date, currentDateTime)
     return seedDate.valueOf()
 }
 

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash'
 
-export function getUTCISOString(date: Date) {
+export function getISODateOnlyString(date: Date) {
     return date.toISOString().split('T')[0]
 }
 

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 
 export function getUTCISOString(date: Date) {
-    return `${date.getUTCFullYear()}-${date.getUTCMonth()}-${date.getUTCDate()}`
+    return date.toISOString().split('T')[0]
 }
 
 export function addDays(date: Date, n: number): Date {

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -1,30 +1,36 @@
 import _ from 'lodash'
 
-export function getTodayWithoutTime(): Date {
-    return getDateWithoutTime(new Date())
-}
-
-export function dateOnlyString(date: Date) {
-    return date.toISOString().split('T')[0]
+export function getUTCISOString(date: Date) {
+    return `${date.getUTCFullYear()}-${date.getUTCMonth()}-${date.getUTCDate()}`
 }
 
 export function addDays(date: Date, n: number): Date {
     const newDate = _.cloneDeep(date)
-    newDate.setDate(newDate.getDate() + n)
+    newDate.setUTCDate(newDate.getUTCDate() + n)
     return newDate
 }
 
 export function addYears(date: Date, n: number): Date {
     const newDate = _.cloneDeep(date)
-    newDate.setFullYear(newDate.getFullYear() + n)
+    newDate.setUTCFullYear(newDate.getUTCFullYear() + n)
     return newDate
 }
 
 export function getDateWithoutTime(date: Date): Date {
-    const day: number = date.getUTCDate()
-    const month: number = date.getUTCMonth()
-    const year: number = date.getUTCFullYear()
-    return new Date(year, month, day)
+    const newDate = _.cloneDeep(date)
+    newDate.setUTCHours(0, 0, 0, 0)
+    return newDate
+}
+
+export function withTimeOf(thisDate: Date, timeSource: Date): Date {
+    const newDate = _.cloneDeep(thisDate)
+    newDate.setUTCHours(
+        timeSource.getUTCHours(),
+        timeSource.getUTCMinutes(),
+        timeSource.getUTCSeconds(),
+        timeSource.getUTCMilliseconds()
+    )
+    return newDate
 }
 
 const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/
@@ -35,5 +41,5 @@ export function ensureValidDate(
 ): Date {
     if (!dateString || !ISO_DATE_REGEX.test(dateString)) return fallbackDate
 
-    return getDateWithoutTime(new Date(dateString))
+    return getDateWithoutTime(new Date(dateString)) // Given a date string in ISO format with no time, Date.parse() assumes UTC
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,5 +32,5 @@
         ]
     },
     "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-    "exclude": ["node_modules", "public/sw.js"]
+    "exclude": ["node_modules", "public/sw.js", "**/*.test.*"]
 }


### PR DESCRIPTION
Honestly this is a little embarrassing, since there are two other PRs I merged attempting to fix this issue. 

Basically, depending on what functions you call for Date objects, it will either use UTC time or local to machine time. If you accidentally use both, you can create discrepancies where the wrong date is used because in 7 hours it rolls over in UTC.

As a result, although I was generating seeds based on UTC time, the validation code was checking against the wrong date.

This time I have included a test verifying the behavior, not so much to prevent regression since I don't expect to change this code, but because before when I thought I had fixed the issue I had not. Best to have some machine verification :)